### PR TITLE
Fix issue number parsing

### DIFF
--- a/jenkins/create-stan-pull-request.sh
+++ b/jenkins/create-stan-pull-request.sh
@@ -19,7 +19,7 @@ curl_success() {
 }
 
 parse_github_issue_number() {
-  github_issue_number=$(sed -n "s,.*/issues/\([0-9]*\)\".*,\1,p" <<< "$1")
+  github_issue_number=$(sed -n "s,.*/issues/\([0-9]*\)\".*,\1,p" <<< "$1" | head -n1)
 }
 
 parse_existing_github_issue_and_pr_numbers() {


### PR DESCRIPTION
We were getting two copies of the issue number due to the way we were
parsing and that was breaking the math build.